### PR TITLE
Avoid generating code that involves deprecated functions (in String mostly)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+*.cm[ioxa]
+*.cmx[as]
+*.[oa]
+*.so
+*.annot
+config/Makefile
+/compiler/camlidl
+/compiler/config.ml
+/compiler/lexer_midl.ml
+/compiler/linenum.ml
+/compiler/parser_midl.ml
+/compiler/parser_midl.mli
+/compiler/parser_midl.output

--- a/compiler/constdecl.ml
+++ b/compiler/constdecl.ml
@@ -31,9 +31,9 @@ let record c =
 (* Declare the constant in ML *)
 
 let ml_declaration oc c =
-  fprintf oc "val %s : " (String.uncapitalize c.cd_name);
+  fprintf oc "val %s : " (String.uncapitalize_ascii c.cd_name);
   match scrape_type c.cd_type with
-    Type_int(_, _) as ty ->
+    Type_int(_, _) as _ty ->
       fprintf oc "%a\n" out_ml_type c.cd_type
   | Type_pointer(_, Type_int((Char | UChar | SChar), _)) |
     Type_array({is_string = true}, _) ->
@@ -51,7 +51,7 @@ let c_declaration oc c =
 
 let ml_definition oc c =
   let v = eval c.cd_value in
-  let name = String.uncapitalize c.cd_name in
+  let name = String.uncapitalize_ascii c.cd_name in
   match scrape_type c.cd_type with
     Type_int((Char | UChar | SChar), _) ->
       fprintf oc "let %s = '%s'\n\n"

--- a/compiler/constdecl.ml
+++ b/compiler/constdecl.ml
@@ -33,7 +33,7 @@ let record c =
 let ml_declaration oc c =
   fprintf oc "val %s : " (String.uncapitalize_ascii c.cd_name);
   match scrape_type c.cd_type with
-    Type_int(_, _) as _ty ->
+    Type_int(_, _) ->
       fprintf oc "%a\n" out_ml_type c.cd_type
   | Type_pointer(_, Type_int((Char | UChar | SChar), _)) |
     Type_array({is_string = true}, _) ->

--- a/compiler/cvttyp.ml
+++ b/compiler/cvttyp.ml
@@ -123,16 +123,16 @@ let out_c_type oc ty = out_c_decl oc ("", ty)
 (* Print an ML type name, qualified if necessary *)
 
 let out_mltype_name oc (modl, name) =
-  if modl <> !module_name then fprintf oc "%s." (String.capitalize modl);
-  output_string oc (String.uncapitalize name)
+  if modl <> !module_name then fprintf oc "%s." (String.capitalize_ascii modl);
+  output_string oc (String.uncapitalize_ascii name)
 
 (* Same, but use stamp if no name is provided *)
 
 let out_mltype_stamp oc kind modl name stamp =
-  if modl <> !module_name then fprintf oc "%s." (String.capitalize modl);
+  if modl <> !module_name then fprintf oc "%s." (String.capitalize_ascii modl);
   if name = ""
   then fprintf oc "%s_%d" kind stamp
-  else output_string oc (String.uncapitalize name)  
+  else output_string oc (String.uncapitalize_ascii name)
 
 (* Convert an IDL type to an ML bigarray element type *)
 
@@ -200,7 +200,7 @@ let rec out_ml_type oc ty =
       if attr.bigarray_maybe_null
       then fprintf oc " option"
   | Type_interface(modl, name) ->
-      fprintf oc "%a Com.interface" out_mltype_name (modl, name)      
+      fprintf oc "%a Com.interface" out_mltype_name (modl, name)
   | Type_const ty' ->
       out_ml_type oc ty'
 

--- a/compiler/enumdecl.ml
+++ b/compiler/enumdecl.ml
@@ -27,9 +27,9 @@ open Enum
 let ml_declaration oc en =
   if en.en_name = ""
   then fprintf oc "enum_%d =\n" en.en_stamp
-  else fprintf oc "%s =\n" (String.uncapitalize en.en_name);
+  else fprintf oc "%s =\n" (String.uncapitalize_ascii en.en_name);
   List.iter
-    (fun c -> fprintf oc "  | %s\n" (String.capitalize c.const_name))
+    (fun c -> fprintf oc "  | %s\n" (String.capitalize_ascii c.const_name))
     en.en_consts
 
 (* Convert an IDL enum declaration to a C enum declaration *)
@@ -99,4 +99,3 @@ let emit_transl oc en =
   emit_transl_table oc en;
   transl_ml_to_c oc en;
   transl_c_to_ml oc en
-

--- a/compiler/file.ml
+++ b/compiler/file.ml
@@ -213,7 +213,7 @@ let gen_c_header oc intf =
   (* Output the header *)
   fprintf oc "/* File generated from %s.idl */\n\n" !module_name;
   (* TODO: emit relevant #include *)
-  let symbname = "_CAMLIDL_" ^ String.uppercase !module_name ^ "_H" in
+  let symbname = "_CAMLIDL_" ^ String.uppercase_ascii !module_name ^ "_H" in
   fprintf oc "\
     #ifndef %s\n\
     #define %s\n\n" symbname symbname;
@@ -234,4 +234,3 @@ let gen_c_header oc intf =
     #endif\n\n";
   fprintf oc "\n\
     #endif /* !%s */\n" symbname
-

--- a/compiler/funct.ml
+++ b/compiler/funct.ml
@@ -67,7 +67,7 @@ let rec split_in_out = function
           match ty with
             Type_array({is_string = true}, _) | Type_bigarray(_, _) ->
               ((name, ty) :: ins, outs)
-          | _ -> 
+          | _ ->
               ((name, ty) :: ins, (name, ty) :: outs)
 
 (* Determine if a typedef represents an error code *)
@@ -101,12 +101,12 @@ let mlname fundecl =
 
 let ml_declaration oc fundecl =
   let (ins, outs) = ml_view fundecl in
-  fprintf oc "external %s : " (String.uncapitalize (mlname fundecl));
+  fprintf oc "external %s : " (String.uncapitalize_ascii (mlname fundecl));
   out_ml_types oc "->" ins;
   fprintf oc " -> ";
   out_ml_types oc "*" outs;
   if List.length ins <= 5
-  then fprintf oc "\n\t= \"camlidl_%s_%s\"\n\n" 
+  then fprintf oc "\n\t= \"camlidl_%s_%s\"\n\n"
                   fundecl.fun_mod fundecl.fun_name
   else fprintf oc "\n\t= \"camlidl_%s_%s_bytecode\" \"camlidl_%s_%s\"\n\n"
                   fundecl.fun_mod fundecl.fun_name
@@ -348,4 +348,3 @@ let emit_method_wrapper oc intf_name meth =
   emit_function oc fundecl ins outs locals
                    (emit_method_call intf_name meth.fun_name);
   current_function := ""
-

--- a/compiler/intf.ml
+++ b/compiler/intf.ml
@@ -43,13 +43,13 @@ let out_method_type oc meth =
 (* Print the ML abstract type identifying the interface *)
 
 let ml_declaration oc intf =
-  fprintf oc "%s\n" (String.uncapitalize intf.intf_name)
+  fprintf oc "%s\n" (String.uncapitalize_ascii intf.intf_name)
 
 (* Declare the class *)
 
 let ml_class_declaration oc intf =
-  let mlintf = String.uncapitalize intf.intf_name in
-  let mlsuper = String.uncapitalize intf.intf_super.intf_name in
+  let mlintf = String.uncapitalize_ascii intf.intf_name in
+  let mlsuper = String.uncapitalize_ascii intf.intf_super.intf_name in
   fprintf oc "class %s_class :\n" mlintf;
   fprintf oc "  %s Com.interface ->\n" mlintf;
   fprintf oc "    object\n";
@@ -59,7 +59,7 @@ let ml_class_declaration oc intf =
   List.iter
     (fun meth ->
       fprintf oc "      method %s: %a\n"
-                 (String.uncapitalize meth.fun_name) out_method_type meth)
+                 (String.uncapitalize_ascii meth.fun_name) out_method_type meth)
     intf.intf_methods;
   fprintf oc "    end\n\n";
   (* Declare the IID *)
@@ -159,8 +159,8 @@ let c_declaration oc intf =
 (* Define the wrapper classes *)
 
 let ml_class_definition oc intf =
-  let intfname = String.uncapitalize intf.intf_name in
-  let supername = String.uncapitalize intf.intf_super.intf_name in
+  let intfname = String.uncapitalize_ascii intf.intf_name in
+  let supername = String.uncapitalize_ascii intf.intf_super.intf_name in
   (* Define the IID *)
   if intf.intf_uid <> "" then
     fprintf oc "let iid_%s = Com._parse_iid \"%s\"\n"
@@ -196,7 +196,7 @@ let ml_class_definition oc intf =
                supername supername intfname;
   List.iter
     (fun meth ->
-      let methname = String.uncapitalize meth.fun_name in
+      let methname = String.uncapitalize_ascii meth.fun_name in
       fprintf oc "    method %s = %s_%s intf\n"
               methname intfname meth.fun_name)
     intf.intf_methods;
@@ -240,7 +240,7 @@ let emit_callback_wrapper oc intf meth =
   for i = 0 to num_ins do fprintf oc "0, " done;
   fprintf oc "};\n";
   fprintf oc "  value _vres;\n";
-  if meth.fun_res <> Type_void then 
+  if meth.fun_res <> Type_void then
     fprintf oc "  %a;\n" out_c_decl ("_res", meth.fun_res);
   (* Convert inputs from C to Caml *)
   let pc = divert_output() in
@@ -257,7 +257,7 @@ let emit_callback_wrapper oc intf meth =
   (* The method label *)
   let label =
     (Obj.magic
-      (Oo.public_method_label (String.uncapitalize meth.fun_name)) : int) in
+      (Oo.public_method_label (String.uncapitalize_ascii meth.fun_name)) : int) in
   (* Do the callback *)
   iprintf pc "_vres = callbackN_exn(caml_get_public_method(_varg[0], Val_int(%d)), %d, _varg);\n"
              label (num_ins + 1);
@@ -309,7 +309,7 @@ let emit_callback_wrapper oc intf meth =
 (* Declare external callback wrapper *)
 
 let declare_callback_wrapper oc intf meth =
-  let (ins, outs) = ml_view meth in
+  let (_ins, _outs) = ml_view meth in
   (* Emit function header *)
   let fun_name =
     sprintf "camlidl_%s_%s_%s_callback"

--- a/compiler/intf.ml
+++ b/compiler/intf.ml
@@ -309,7 +309,6 @@ let emit_callback_wrapper oc intf meth =
 (* Declare external callback wrapper *)
 
 let declare_callback_wrapper oc intf meth =
-  let (_ins, _outs) = ml_view meth in
   (* Emit function header *)
   let fun_name =
     sprintf "camlidl_%s_%s_%s_callback"

--- a/compiler/lexpr.ml
+++ b/compiler/lexpr.ml
@@ -265,11 +265,11 @@ let rec tstype trail = function
   | Type_pointer(attr, ty) ->
       tstype (sprintf "*%s" trail) ty
   | Type_array(attr, ty) ->
-      let _trail' =
+      let trail' =
         match attr.bound with
           Some n -> sprintf "%s[]" trail
         | None -> sprintf "*%s" trail in
-      tstype trail ty
+      tstype trail' ty
   | Type_bigarray(attr, ty) ->
       tstype (sprintf "*%s" trail) ty
   | Type_interface(modl, intf_name) ->

--- a/compiler/lexpr.ml
+++ b/compiler/lexpr.ml
@@ -85,7 +85,7 @@ let string_val = function
 let expand_typedef = ref ((fun _ -> assert false) : string -> idltype)
 
 let rec cast_value ty v =
-  match ty with  
+  match ty with
     Type_int(kind, _) ->
       begin match kind with
         Int | UInt -> Cst_int(int32_val v)
@@ -265,7 +265,7 @@ let rec tstype trail = function
   | Type_pointer(attr, ty) ->
       tstype (sprintf "*%s" trail) ty
   | Type_array(attr, ty) ->
-      let trail' =
+      let _trail' =
         match attr.bound with
           Some n -> sprintf "%s[]" trail
         | None -> sprintf "*%s" trail in
@@ -466,4 +466,3 @@ let rec is_dependent v ty =
   | Type_const ty ->
       is_dependent v ty
   | _ -> false
-

--- a/compiler/parse_aux.ml
+++ b/compiler/parse_aux.ml
@@ -97,7 +97,7 @@ let make_bigarray ty =
       (List.rev dims, ty) in
   let (dims, ty_tail) = extract_spine [] ty in
   match ty_tail with
-    Type_int(_,_) | Type_float | Type_double 
+    Type_int(_,_) | Type_float | Type_double
   | Type_const(Type_int(_,_) | Type_float | Type_double) ->
       Type_bigarray({dims = dims; fortran_layout = false; malloced = false;
                      bigarray_maybe_null = false},
@@ -164,11 +164,11 @@ let rec apply_type_attribute ty attr =
   | (("managed", _), Type_bigarray(attrs, ty_elt)) ->
       Type_bigarray({attrs with malloced = true}, ty_elt)
   | (("switch_is", [rexp]), Type_union(name, attr)) ->
-      Type_union(name, {attr with discriminant = rexp})
+      Type_union(name, {discriminant = rexp})
   | (("switch_is", [rexp]), Type_pointer(attr, Type_union(name, attr'))) ->
-      Type_pointer(attr, Type_union(name, {attr' with discriminant = rexp}))
+      Type_pointer(attr, Type_union(name, {discriminant = rexp}))
   | (("set", _), Type_enum(name, attr)) ->
-      Type_enum(name, {attr with bitset = true})
+      Type_enum(name, {bitset = true})
   | ((("context_handle" | "switch_type"), _), _) ->
       ty (*ignored*)
   | ((name, rexps), Type_pointer(attr, ty_elt)) when is_star_attribute name ->
@@ -227,7 +227,7 @@ let make_fun_declaration attrs ty_res name params quotes =
   and dealloc = ref None
   and blocking = ref false in
   let parse_quote (label, text) =
-    match String.lowercase label with
+    match String.lowercase_ascii label with
       "call" -> call := Some text
     | "dealloc" | "free" -> dealloc := Some text
     | _ ->
@@ -456,7 +456,7 @@ let make_forward_interface name =
 
 let make_diversion (id, txt) =
   let kind =
-    match String.lowercase id with
+    match String.lowercase_ascii id with
       "" | "c" -> Div_c
     | "h" -> Div_h
     | "ml" -> Div_ml
@@ -481,7 +481,7 @@ let make_int kind =
 
 let make_unsigned kind =
   make_int (match kind with
-             Int -> UInt | Long -> ULong | Hyper -> UHyper 
+             Int -> UInt | Long -> ULong | Hyper -> UHyper
            | Small -> USmall | Short -> UShort | Char -> UChar | SChar -> UChar
            | k -> k)
 
@@ -516,7 +516,7 @@ let make_star_attribute (name, args) = ("*" ^ name, args)
 let make_type_const ty =
   match ty with
     Type_const _ ->
-      eprintf "%t: Warning: multiple `const' modifiers on a type.\n" 
+      eprintf "%t: Warning: multiple `const' modifiers on a type.\n"
               print_location;
       ty
   | _ -> Type_const ty

--- a/compiler/parse_aux.ml
+++ b/compiler/parse_aux.ml
@@ -164,11 +164,11 @@ let rec apply_type_attribute ty attr =
   | (("managed", _), Type_bigarray(attrs, ty_elt)) ->
       Type_bigarray({attrs with malloced = true}, ty_elt)
   | (("switch_is", [rexp]), Type_union(name, attr)) ->
-      Type_union(name, {discriminant = rexp})
+      Type_union(name, {attr with discriminant = rexp})
   | (("switch_is", [rexp]), Type_pointer(attr, Type_union(name, attr'))) ->
-      Type_pointer(attr, Type_union(name, {discriminant = rexp}))
+      Type_pointer(attr, Type_union(name, {attr' with discriminant = rexp}))
   | (("set", _), Type_enum(name, attr)) ->
-      Type_enum(name, {bitset = true})
+      Type_enum(name, {attr with bitset = true})
   | ((("context_handle" | "switch_type"), _), _) ->
       ty (*ignored*)
   | ((name, rexps), Type_pointer(attr, ty_elt)) when is_star_attribute name ->

--- a/compiler/structdecl.ml
+++ b/compiler/structdecl.ml
@@ -27,7 +27,7 @@ open Struct
 let ml_declaration oc sd =
   if sd.sd_name = ""
   then fprintf oc "struct_%d = " sd.sd_stamp
-  else fprintf oc "%s = " (String.uncapitalize sd.sd_name);
+  else fprintf oc "%s = " (String.uncapitalize_ascii sd.sd_name);
   match remove_dependent_fields sd.sd_fields with
     [f] ->
       fprintf oc "%a\n" out_ml_type f.field_typ
@@ -36,7 +36,7 @@ let ml_declaration oc sd =
       List.iter
         (fun f ->
           fprintf oc "  %s: %a;\n"
-                  (String.uncapitalize f.field_mlname)
+                  (String.uncapitalize_ascii f.field_mlname)
                   out_ml_type f.field_typ)
         fields;
       fprintf oc "}\n"
@@ -98,4 +98,3 @@ let transl_c_to_ml oc sd =
 let emit_transl oc sd =
   transl_ml_to_c oc sd;
   transl_c_to_ml oc sd
-

--- a/compiler/typedef.ml
+++ b/compiler/typedef.ml
@@ -45,12 +45,12 @@ let find =
 let ml_declaration oc td =
   match td with
     {td_mltype = Some s} ->
-      fprintf oc "%s = %s\n" (String.uncapitalize td.td_name) s
+      fprintf oc "%s = %s\n" (String.uncapitalize_ascii td.td_name) s
   | {td_abstract = true} ->
-      fprintf oc "%s\n" (String.uncapitalize td.td_name)
+      fprintf oc "%s\n" (String.uncapitalize_ascii td.td_name)
   | _ ->
       fprintf oc "%s = %a\n"
-              (String.uncapitalize td.td_name) out_ml_type td.td_type
+              (String.uncapitalize_ascii td.td_name) out_ml_type td.td_type
 
 (* Generate the C typedef corresponding to the typedef *)
 
@@ -235,5 +235,3 @@ let emit_transl oc td =
   | None ->
       transl_c_to_ml oc td
   end
-
-

--- a/compiler/uniondecl.ml
+++ b/compiler/uniondecl.ml
@@ -27,19 +27,19 @@ open Union
 let ml_declaration oc ud =
   if ud.ud_name = ""
   then fprintf oc "union_%d =\n" ud.ud_stamp
-  else fprintf oc "%s =\n" (String.uncapitalize ud.ud_name);
+  else fprintf oc "%s =\n" (String.uncapitalize_ascii ud.ud_name);
   let out_constr oc c =
     if c = "default" then
       if ud.ud_name <> ""
       then fprintf oc "Default_%s" ud.ud_name
       else fprintf oc "Default_%d" ud.ud_stamp
     else
-      output_string oc (String.capitalize c) in
+      output_string oc (String.capitalize_ascii c) in
   let emit_case = function
     {case_labels = []; case_field = None} -> (* default case, no arg *)
       fprintf oc "  | %a of int\n" out_constr "default"
   | {case_labels = []; case_field = Some f} -> (* default case, one arg *)
-      fprintf oc "  | %a of int * %a\n" 
+      fprintf oc "  | %a of int * %a\n"
                  out_constr "default" out_ml_type f.field_typ
   | {case_labels = lbls; case_field = None} -> (* named cases, no args *)
       List.iter

--- a/compiler/utils.ml
+++ b/compiler/utils.ml
@@ -48,7 +48,7 @@ let divert_output() =
 let end_diversion oc =
   close_out !temp_out;
   let ic = open_in !temp_file in
-  let buffer = String.create 256 in
+  let buffer = Bytes.create 256 in
   let rec copy() =
     let n = input ic buffer 0 256 in
     if n > 0 then (output oc buffer 0 n; copy()) in
@@ -109,4 +109,3 @@ let find_in_path path name =
 (* Discard result *)
 
 (*external ignore: 'a -> unit = "%identity" (* not quite *)*)
-


### PR DESCRIPTION
- String.{{un}capitalize,lowercase} -> String.{{un}capitalize,lowercase}_ascii
- String.create -> Bytes.create
- Also fix useless `with' clauses

Note the previous changes require OCaml ≥ 4.03 for compiling camlidl itself. Yet all this allows a smooth transition towards generating code that comply with immutability of strings in OCaml ≥ 4.06 (another pull request soon to come).

- Add a .gitignore