### PR TITLE
Detect .so/.dll in case of a mingw build

### DIFF
--- a/runtime/Makefile.unix
+++ b/runtime/Makefile.unix
@@ -14,9 +14,15 @@
 
 OBJS=idlalloc.o comintf.o comerror.o
 
-all: dllcamlidl.so libcamlidl.a
+ifeq ($(OS),Windows_NT)
+SO:=dll
+else
+SO:=so
+endif
 
-dllcamlidl.so libcamlidl.a: $(OBJS)
+all: dllcamlidl.$(SO) libcamlidl.a
+
+dllcamlidl.$(SO) libcamlidl.a: $(OBJS)
 	- rm -f $@
 	ocamlmklib -o camlidl  $(OBJS) 
 
@@ -28,7 +34,7 @@ dllcamlidl.so libcamlidl.a: $(OBJS)
 install:
 	cp camlidlruntime.h $(OCAMLLIB)/caml/camlidlruntime.h
 	cp libcamlidl.a $(OCAMLLIB)/libcamlidl.a
-	cp dllcamlidl.so $(OCAMLLIB)/stublibs/dllcamlidl.so
+	cp dllcamlidl.$(SO) $(OCAMLLIB)/stublibs/dllcamlidl.$(SO)
 	cd $(OCAMLLIB); $(RANLIB) libcamlidl.a
 
 clean:


### PR DESCRIPTION
On a Mingw build, dynamic libraries have a `.dll` extension. Detect this accordingly.

I'm aware of the `Makefile.win32`/`Makefile.unix` distinction, but the Unix Makefile works perfectly for a Cygwin+Mingw build. It feels wasteful to create a third Makefile just for this. I believe this approach would signficantly reduce the size of https://github.com/fdopen/opam-repository-mingw/blob/master/packages/camlidl/camlidl.1.05/files/camlidl-1.05.patch