### PR TITLE
fix linking in bytecode

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -43,7 +43,7 @@ install:
 
 # Clean up
 clean::
-	rm -f *.cm[ioax] $.cmxa *~
+	rm -f *.cm[ioax] *.cmxa *.[ao] *.lib *~
 
 # Dependencies
 depend:

--- a/runtime/Makefile.unix
+++ b/runtime/Makefile.unix
@@ -32,7 +32,7 @@ install:
 	cd $(OCAMLLIB); $(RANLIB) libcamlidl.a
 
 clean:
-	rm -f *.a *.o
+	rm -f *.a *.o *.so
 
 .SUFFIXES: .c .o
 

--- a/runtime/comintf.c
+++ b/runtime/comintf.c
@@ -91,12 +91,12 @@ camlidl_QueryInterface(struct camlidl_intf * this, REFIID iid,
       return S_OK;
     }
   }
+#ifdef _WIN32
   if (IsEqualIID(iid, &IID_IUnknown)) {
     *object = (void *) this;
     InterlockedIncrement(&(comp->refcount));
     return S_OK;
   }
-#ifdef _WIN32
   if (this->typeinfo != NULL && IsEqualIID(iid, &IID_IDispatch)) {
     *object = (void *) this;
     InterlockedIncrement(&(comp->refcount));

--- a/runtime/comstuff.h
+++ b/runtime/comstuff.h
@@ -40,7 +40,6 @@ interface IUnknown {
 #define IsEqualIID(a,b) (memcmp(a, b, sizeof(IID)) == 0)
 #define InterlockedIncrement(p) (++(*(p)))
 #define InterlockedDecrement(p) (--(*(p)))
-extern IID IID_IUnknown;
 #define S_TRUE S_OK
 #define S_FALSE 1
 #define E_NOINTERFACE 0x80004002


### PR DESCRIPTION
after d8f7a3f9a3999c17c6ee61ebbc6051136aed3bb8 it became possible to link libcamlidl.a on linux to bytecode custom binaries, but pure bytecode link will fail with IID_IUnknown unresolved :
```
 Error: Error on dynamically loaded library: /home/ygrek/example/_opam/lib/stublibs/dllcamlidl.so: /home/ygrek/example/_opam/lib/stublibs/dllcamlidl.so: undefined symbol: IID_IUnknown
```
(there is also a case of META file tweak required but it is currently maintained in opam-repository and I will fix it there when needed)

This PR removes IID_IUnknown from dllcamlidl.so and libcamlidl.a. My reasoning is that it can only be resolved on windows so the only usage of IID_IUnknown that was affecting build on linux is now also hidden under WIN32 define.