### PR TITLE
use DESTDIR during installation

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -40,10 +40,10 @@ $(NATIVELIB): $(NATIVEOBJS)
 	$(OCAMLOPT) -a -o $(NATIVELIB) -cclib -lcamlidl $(NATIVEOBJS)
 
 installbyt:
-	cp -p $(INTERFACES) $(BYTELIB) $(OCAMLLIB)
+	cp -p $(INTERFACES) $(BYTELIB) $(DESTDIR)$(OCAMLLIB)
 
 installopt:
-	cp -p $(NATIVELIB) $(NATIVELIB:.cmxa=.$(LIBEXT)) $(OCAMLLIB)
+	cp -p $(NATIVELIB) $(NATIVELIB:.cmxa=.$(LIBEXT)) $(DESTDIR)$(OCAMLLIB)
 
 .SUFFIXES: .mli .ml .cmi .cmo .cmx
 

--- a/runtime/Makefile.unix
+++ b/runtime/Makefile.unix
@@ -26,10 +26,10 @@ dllcamlidl.so libcamlidl.a: $(OBJS)
 #	$(RANLIB) $@
 
 install:
-	cp camlidlruntime.h $(OCAMLLIB)/caml/camlidlruntime.h
-	cp libcamlidl.a $(OCAMLLIB)/libcamlidl.a
-	cp dllcamlidl.so $(OCAMLLIB)/stublibs/dllcamlidl.so
-	cd $(OCAMLLIB); $(RANLIB) libcamlidl.a
+	cp camlidlruntime.h $(DESTDIR)$(OCAMLLIB)/caml/camlidlruntime.h
+	cp libcamlidl.a $(DESTDIR)$(OCAMLLIB)/libcamlidl.a
+	cp dllcamlidl.so $(DESTDIR)$(OCAMLLIB)/stublibs/dllcamlidl.so
+	cd $(DESTDIR)$(OCAMLLIB); $(RANLIB) libcamlidl.a
 
 clean:
 	rm -f *.a *.o *.so


### PR DESCRIPTION
During the installation most of the installer put the file in a different tree. Then all file are tracked and moved to the real destination