### PR TITLE
Allow length_is on output arrays to reference output values

### DIFF
--- a/compiler/idlarray.ml
+++ b/compiler/idlarray.ml
@@ -189,7 +189,7 @@ let array_c_to_ml c_to_ml oc pref attr ty_elt c v =
     end
   end
 
-(* Determine the output size of an array *)
+(* Determine the output size of an array (for ML array creation - valid count) *)
 
 let array_output_size attr =
   match attr with
@@ -198,12 +198,21 @@ let array_output_size attr =
   | {bound = Some le} -> le
   | _ -> error "Cannot determine array size for C -> ML conversion"
 
+(* Determine the allocation size of an array (buffer capacity) *)
+
+let array_alloc_size attr =
+  match attr with
+    {size = Some re} -> re
+  | {length = Some re} -> re
+  | {bound = Some le} -> le
+  | _ -> error "Cannot determine array size for allocation"
+
 (* Allocate room for an out array *)
 
 let array_allocate_output_space oc pref attr ty_elt c =
   if attr.bound = None then begin
     iprintf oc "%s = camlidl_malloc(%a * sizeof(%a), _ctx);\n"
-               c Lexpr.output (pref, array_output_size attr)
+               c Lexpr.output (pref, array_alloc_size attr)
                out_c_type ty_elt;
     need_context := true
   end

--- a/compiler/lexpr.ml
+++ b/compiler/lexpr.ml
@@ -379,7 +379,10 @@ let tostr pref e =
     | e -> ts9 e
 
   and ts9 = function
-      Expr_ident s ->
+      Expr_ident "_return" ->
+        (* Special identifier for function return value *)
+        add_string b "_res"
+    | Expr_ident s ->
         begin try
           match Hashtbl.find const_val s with
             Cst_int n ->

--- a/doc/manual.etex
+++ b/doc/manual.etex
@@ -536,6 +536,39 @@ of the array.  For instance, "[size_is(*dimx, *dimy)] double d[][]"
 specifies a matrix of "double" whose first dimension has size
 "*dimx" and the second has size "*dimy".
 
+For "[out]" arrays, "size_is" and "length_is" have distinct meanings:
+"size_is" specifies the allocation size (buffer capacity), while
+"length_is" specifies the valid element count.  When both are given,
+"size_is" determines how much memory to allocate for the C array, and
+"length_is" determines how many elements to copy to the resulting ML
+array.  When only one is given, it is used for both purposes.
+
+On "[out]" or "[in,out]" arrays, "length_is" can reference output
+values: the special identifier "_return" refers to the function's
+return value, and dereferenced "[out]" parameters (e.g., "*n") can
+also be used.  When "length_is" references an output value, that value
+is omitted from the ML function's result since it is encoded in the
+array length.  For example, consider a C function:
+\begin{alltt}
+unsigned int fill_upto(int n, int a[]);
+\end{alltt}
+that takes an array "a" of size "n", fills a prefix of the array with at
+most "n" values, and returns the number of values stored. The IDL
+declaration:
+\begin{alltt}
+unsigned int fill_upto([in] int n, [out,size_is(n),length_is(_return)] int a[]);
+\end{alltt}
+expresses that "a" is allocated enough space for "n" elements, and upon
+return only the prefix of length given by the return value contains valid
+values. This compiles to an ML function:
+\begin{alltt}
+fill_upto : int -> int array
+\end{alltt}
+where the array length equals the C function's return value. Crucially, the
+unfilled portion of the array is not converted from C to ML.
+
+Using "length_is" with output expressions on "[in]" arrays is an error.
+
 \subsection{Big arrays}
 
 IDL arrays of integers or floats that carry the "[bigarray]" attribute
@@ -564,6 +597,11 @@ Finally, the "[unique]" attribute applies to bigarrays as to arrays,
 that is, it maps a null C pointer to "None", and a non-null C pointer
 \var{p} to "Some("\var{v}")" where \var{v} is the ML bigarray
 resulting from the translation of \var{p}.
+
+Note that "[length_is]" with output expressions does not apply to bigarrays,
+since bigarrays are not copied during conversion---they share memory with
+the underlying C array---and therefore cannot be resized based on an output
+length.
 
 \subsection{Structs}
 
@@ -845,6 +883,17 @@ void n([in] int inputlen, [out] int * outputlen,
 \begin{quote} The two parameters "inputlen" and "outputlen" are
 dependent, hence ignored.  The "double" array is both an input
 and an output. \end{quote}
+\begin{alltt}
+unsigned int o([in] int maxlen,
+               [out,size_is(maxlen),length_is(_return)] int r[])
+                                                o : int -> int array
+\end{alltt}
+\begin{quote} The "length_is(_return)" attribute indicates that the
+function's return value determines the valid length of the output array.
+The return value is omitted from the Caml function's result since it is
+encoded in the array length.  The "size_is" attribute specifies the
+allocated buffer size, while "length_is" specifies the valid element count.
+\end{quote}
 \begin{alltt}
 void p([in] int dimx, [in] int dimy,
        [in,out,bigarray,size_is(dimx,dimy)] double d[][])

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,7 +6,7 @@ INCLUDES=-DCAML_NAME_SPACE -I.. -I$(OCAMLLIB)
 CCPP?=$(CC)
 CPPFLAGS=$(CFLAGS)
 
-TESTS=basics.idl arrays.idl structs.idl unions.idl typedefs.idl $(TESTS_$(OSTYPE)) multi_import.idl stdint.idl
+TESTS=basics.idl arrays.idl structs.idl unions.idl typedefs.idl $(TESTS_$(OSTYPE)) multi_import.idl stdint.idl array_length.idl
 TESTS_unix=unix.idl
 COMLIBS=$(COMLIBS_$(OSTYPE))
 COMLIBS_win32=advapi32.lib ole32.lib oleaut32.lib

--- a/tests/array_length.idl
+++ b/tests/array_length.idl
@@ -1,0 +1,55 @@
+/* length_is with output parameter */
+void
+fill_array(
+  [in] int max_size,
+  [out] int *actual_size,
+  [out, size_is(max_size), length_is(*actual_size)] int results[]);
+
+/* length_is with return value */
+unsigned int
+get_results(
+  [in] int max_size,
+  [out, size_is(max_size), length_is(_return)] int results[]);
+
+/* combined with input array */
+int
+process(
+  [in] int n,
+  [in, length_is(n)] int input[],
+  [out, size_is(n), length_is(_return)] int output[]);
+
+/* 2D array - first dim from return, second from size_is */
+unsigned int
+get_matrix_rows(
+  [in] int max_rows,
+  [in] int cols,
+  [out, size_is(max_rows, cols), length_is(_return,)] int matrix[][]);
+
+/* 2D array - first dim from size_is, second from output param */
+void
+get_sparse_rows(
+  [in] int num_rows,
+  [in] int max_cols,
+  [out] int *actual_cols,
+  [out, size_is(num_rows, max_cols), length_is(, *actual_cols)] int data[][]);
+
+/* 2D array - both dims from output params */
+void
+get_variable_matrix(
+  [in] int max_rows,
+  [in] int max_cols,
+  [out] int *actual_rows,
+  [out] int *actual_cols,
+  [out, size_is(max_rows, max_cols), length_is(*actual_rows, *actual_cols)] int matrix[][]);
+
+/* return value and output param for different dims */
+unsigned int
+get_result_matrix(
+  [in] int max_rows,
+  [in] int max_cols,
+  [out] int *actual_cols,
+  [out, size_is(max_rows, max_cols), length_is(_return, *actual_cols)] int matrix[][]);
+
+/* 2D return pointer with multiple out params for dimensions */
+[length_is(*rows, *cols)] int **
+get_matrix([out] unsigned int *rows, [out] unsigned int *cols);


### PR DESCRIPTION
The length_is attribute can now reference output expressions (like _return
or *out_param) when used on [out] or [in,out] arrays. This specifies the
valid length of an output array when it is determined at runtime. The
referenced value is omitted from the OCaml function's result since it is
encoded in the array length.

Example:
  unsigned int fill_upto(
    [in] int n,
    [out, size_is(n), length_is(_return)] int a[]);

generates:
  fill_upto : int -> int array

The size_is attribute specifies the allocation size, while length_is
specifies the valid element count. The special identifier _return
references the function's return value.

Using length_is with output expressions on [in] arrays is an error.

Signed-off-by: Josh Berdine <josh@berdine.net>